### PR TITLE
devuelve idRol al iniciar sesion

### DIFF
--- a/api/usuarios/login.php
+++ b/api/usuarios/login.php
@@ -22,13 +22,16 @@
     }
 
   if($usuario->login()){
-      echo json_encode(
-          array('code' => 0,'message'=> 'Usuario logueado')
+    try{
+      $usuario->get_user_role();
+    } finally{
+      $session_array = array(
+        'code' => 0, 'message' => 'Usuario logueado', 'idRol' => $usuario->idRol
       );
+        echo json_encode($session_array);;
+    }
     }else{
         echo json_encode(
             array('code' => 1, 'error' => 'El usuario o contraseña es incorrecto.')
         );
     }
-      
-?>

--- a/models/Usuario.php
+++ b/models/Usuario.php
@@ -63,6 +63,18 @@ class Usuario{
         return $verificaClave;
     }
 
+    public function get_user_role(){
+        $query = 'SELECT idRol FROM ' . $this->tabla . ' WHERE nombreUsuario = ? LIMIT 1';
+        $stmt = $this->connection->prepare($query);
+
+        $stmt->bindParam(1, $this->nombreUsuario);
+        $stmt->execute();
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        $this->idRol = $row['idRol'];
+    }
+
 
 
 }


### PR DESCRIPTION
Resuelve la Issue #6. Al iniciar sesión se devuelve el id del rol al que pertenece el usuario. Al ser solo dos roles, si él id de rol es 1 se debe proceder a mostrar la pantalla principal del administrador, si es 2 la pantalla principal del vendedor.